### PR TITLE
Replace KeychainAccess With Native Keychain Implementation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -18,15 +18,6 @@
           "revision": "22e3d174e9df2962f0268a31dac45e5ea54a6e62",
           "version": "2.6.1"
         }
-      },
-      {
-        "package": "KeychainAccess",
-        "repositoryURL": "https://github.com/kishikawakatsumi/KeychainAccess.git",
-        "state": {
-          "branch": null,
-          "revision": "8d33ffd6f74b3bcfc99af759d4204c6395a3f918",
-          "version": "3.2.1"
-        }
       }
     ]
   },

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.2.0")),
-        .package(name: "JWTDecode", url: "https://github.com/auth0/JWTDecode.swift.git", .upToNextMajor(from: "2.6.1")),
-        .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", .upToNextMajor(from: "3.0.0"))
+        .package(name: "JWTDecode", url: "https://github.com/auth0/JWTDecode.swift.git", .upToNextMajor(from: "2.6.1"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/PrivoSDK/model/DeviceIdentifier.swift
+++ b/Sources/PrivoSDK/model/DeviceIdentifier.swift
@@ -6,19 +6,46 @@
 //
 
 import UIKit
-import KeychainAccess
 
 struct DeviceIdentifier {
     public let identifier: String
     private let deviceIdentifierKey = "privo-device-identifier"
+    
+    private static var baseQuery: [String: Any] {
+        [kSecAttrService as String: PrivoInternal.configuration.privoServiceKey,
+         kSecClass as String: kSecClassGenericPassword]
+    }
+    
+    private static var searchQuery: [String: Any] {
+        [kSecMatchLimit as String: kSecMatchLimitOne,
+         kSecReturnAttributes as String: true,
+         kSecReturnData as String: true]
+            .merging(baseQuery, uniquingKeysWith: { (current, _) in current })
+    }
+    
     init () throws {
-        let keychain = Keychain(service: PrivoInternal.configuration.privoServiceKey)
-        if let identifier = keychain[deviceIdentifierKey] {
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(DeviceIdentifier.searchQuery as CFDictionary, &item)
+        
+        if status != errSecItemNotFound {
+            guard let existingItem = item as? [String : Any],
+                  let identifierData = existingItem[kSecValueData as String] as? Data,
+                  let identifier = String(data: identifierData, encoding: String.Encoding.utf8) else {
+                throw KeychainError.unexpectedPasswordData
+            }
             self.identifier = identifier
         } else {
             let newIdentifier = UIDevice.current.identifierForVendor!.uuidString
-            keychain[deviceIdentifierKey] = newIdentifier
+            let addQuery = [kSecValueData as String: newIdentifier].merging(DeviceIdentifier.baseQuery, uniquingKeysWith: { (current, _) in current })
+            
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            guard addStatus == errSecSuccess else { throw KeychainError.unhandledError(status: addStatus) }
             self.identifier = newIdentifier
         }
     }
+}
+
+enum KeychainError: Error {
+    case unexpectedPasswordData
+    case unhandledError(status: OSStatus)
 }


### PR DESCRIPTION
This is related to #17 

Since this is being used for a simple read/write operation, doing it natively helps reduce number of dependencies.

I know the native way adds a lot of boilerplate code, but it's a simple add.