### PR TITLE
PRIV-7118: Support Age Estimation flow in Age Gate Module of IOS SDK

### DIFF
--- a/Sources/PrivoSDK/components/Webview.swift
+++ b/Sources/PrivoSDK/components/Webview.swift
@@ -57,6 +57,7 @@ struct Webview: UIViewRepresentable {
         wkPreferences.javaScriptCanOpenWindowsAutomatically = true
         let configuration = WKWebViewConfiguration()
         configuration.preferences = wkPreferences
+        configuration.allowsInlineMediaPlayback = true
         
         let webview = WKWebView(frame: .zero, configuration: configuration)
         webview.configuration.preferences.setValue(true, forKey: "developerExtrasEnabled")


### PR DESCRIPTION
There has been missed a flag for working camera in WebKit by using Native's permissions.