### PR TITLE
PRIV-7839: Improved analytic error handling.

### DIFF
--- a/Sources/PrivoSDK/PrivoAgeGate.swift
+++ b/Sources/PrivoSDK/PrivoAgeGate.swift
@@ -15,6 +15,10 @@ public class PrivoAgeGate {
         ageGate = PrivoAgeGateInternal()
     }
     
+    init(urlConfig: URLSessionConfiguration) {
+        ageGate = PrivoAgeGateInternal(api: Rest(urlConfig: urlConfig))
+    }
+    
     public func getStatus(userIdentifier: String?, nickname: String? = nil, completionHandler: @escaping (AgeGateEvent) -> Void) throws {
         Task.init {
             try ageGate.helpers.checkNetwork()

--- a/Sources/PrivoSDK/api/Rest.swift
+++ b/Sources/PrivoSDK/api/Rest.swift
@@ -8,6 +8,22 @@
 import Alamofire
 import Foundation
 
+
+extension URL {
+    var status: URL {
+        return self.appendingPathComponent("status")
+    }
+    
+    var analytic: URL {
+        return self.appendingPathComponent("metrics")
+    }
+    
+    var isAnalytic: Bool {
+        return self.absoluteString.hasSuffix("metrics")
+    }
+}
+
+
 class Rest {
     
     //MARK: - Static Shared object
@@ -184,8 +200,7 @@ class Rest {
     }
     
     func sendAnalyticEvent(_ event: AnalyticEvent) {
-        var url = PrivoInternal.configuration.commonUrl
-        url.appendPathComponent("metrics")
+        var url = PrivoInternal.configuration.commonUrl.analytic
         session.request(url, method: .post, parameters: event, encoder: JSONParameterEncoder.default).response { r in
             print("Analytic Event Sent")
             print(r)
@@ -277,9 +292,9 @@ class Rest {
     }
     
     func processStatus(data: StatusRecord) async -> AgeGateStatusResponse? {
-        let url = String(format: "%@/status", PrivoInternal.configuration.ageGateBaseUrl.absoluteString)
+        let url = PrivoInternal.configuration.ageGateBaseUrl.status
         typealias R = DataResponse<AgeGateStatusResponse,AFError>
-        let result: R = await session.request(url,
+        let result: R = await session.request(url.absoluteString,
                                          method: .put,
                                          parameters: data,
                                          encoder: JSONParameterEncoder.default,

--- a/Sources/PrivoSDK/api/Rest.swift
+++ b/Sources/PrivoSDK/api/Rest.swift
@@ -38,8 +38,6 @@ extension URL {
     func hasSuffix(_ component: URLComponentConstants) -> Bool {
         return self.absoluteString.hasSuffix(component.rawValue)
     }
-    
-    }
 }
 
 

--- a/Sources/PrivoSDK/api/Rest.swift
+++ b/Sources/PrivoSDK/api/Rest.swift
@@ -14,13 +14,20 @@ class Rest {
     
     static var shared: Rest = .init()
     
+    init(urlConfig: URLSessionConfiguration = URLSessionConfiguration.af.default) {
+        self.urlConfig = urlConfig
+        self.session = Session(configuration: urlConfig)
+    }
+    
     //MARK: - Private properties
     
     private static let storageComponent = "storage"
     private static let putComponent = "put"
     private static let sessionID = "session_id"
     private static let emptyResponsesCodes: Set<Int> = .init([200,204,205])
-    private let session = Session.default
+    
+    private let urlConfig: URLSessionConfiguration
+    private let session: Session
     
     //MARK: - Internal functions
     

--- a/Sources/PrivoSDK/api/Rest.swift
+++ b/Sources/PrivoSDK/api/Rest.swift
@@ -173,7 +173,7 @@ class Rest {
     
     func trackPossibleAFError(_ error: AFError?, _ response: String?, _ code: Int?) {
         let encoder = JSONEncoder()
-        var analyticErrorEvent: AnalyticEventErrorData? = nil
+        let analyticErrorEvent: AnalyticEventErrorData?
         
         if (code != 200 && code != 204 && code != 205) {
             // This branch for HTTP errors.
@@ -189,6 +189,8 @@ class Rest {
                                                         response: response,
                                                         errorCode: error.responseCode,
                                                         privoSettings: nil)
+        } else {
+            analyticErrorEvent = nil
         }
         
         if let analyticErrorEvent,

--- a/Sources/PrivoSDK/extensions/URL.swift
+++ b/Sources/PrivoSDK/extensions/URL.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension URL {
-
+    // Since iOS16 min support version use URL.appending(queryItems: [URLQueryItem]) -> URL
     func withQueryParam(name: String, value: String?) -> URL? {
         if var urlComponents = URLComponents(string: self.absoluteString) {
             // Create array of existing query items

--- a/Sources/PrivoSDK/model/AnalyticEvent.swift
+++ b/Sources/PrivoSDK/model/AnalyticEvent.swift
@@ -23,3 +23,7 @@ struct AnalyticEvent : Encodable {
     var svc = 62 // PrivoIosSDK
     var event = 299 // MetricUnexpectedError
 }
+
+// conforms Decodable for test purposes
+extension AnalyticEventErrorData: Decodable {}
+extension AnalyticEvent: Decodable {}

--- a/Sources/PrivoSDK/model/EnviromentType.swift
+++ b/Sources/PrivoSDK/model/EnviromentType.swift
@@ -12,3 +12,6 @@ public enum EnviromentType: Int, Equatable, CaseIterable, Encodable {
     case Test
     case Prod
 }
+
+// conforms Decodable for test purposes
+extension EnviromentType: Decodable {}

--- a/Sources/PrivoSDK/model/PrivoSettings.swift
+++ b/Sources/PrivoSDK/model/PrivoSettings.swift
@@ -15,3 +15,6 @@ public struct PrivoSettings: Encodable {
         self.apiKey = apiKey
     }
 }
+
+// conforms Decodable for test purposes
+extension PrivoSettings: Decodable {}

--- a/Tests/PrivoSDKTests/PrivoSDKTests.swift
+++ b/Tests/PrivoSDKTests/PrivoSDKTests.swift
@@ -7,24 +7,23 @@ final class PrivoSDKTests: XCTestCase {
     // MARK: - analytics event logs
     
     func test_analytics_event() async {
-        // GIVEN
-        // configured one bad response:
         Privo.initialize(settings: PrivoSettings(serviceIdentifier: "privolock", envType: .Dev))
         
+        // configured one bad response:
         let statusURL = PrivoInternal.configuration.ageGateBaseUrl.status
         let headers = [
             "Content-Length": "42",
         ]
-        
-        let response = HTTPURLResponse(url: statusURL, statusCode: 404, httpVersion: nil, headerFields: headers)
-        
+        let badResponse = HTTPURLResponse(url: statusURL, statusCode: 404, httpVersion: nil, headerFields: headers)
+
+        // mock requests
         URLMock.urls = [statusURL: (error: nil,
-                                      data: "The requested resource could not be found.".data(using: .utf8),
-                                      response: response)]
-        
+                                     data: "The requested resource could not be found.".data(using: .utf8),
+                                 response: badResponse)]
         let urlConfig: URLSessionConfiguration = .default
         urlConfig.protocolClasses = [ URLMock.self ]
         
+        // GIVEN
         let ageGate = PrivoAgeGate(urlConfig: urlConfig)
         
         // WHEN

--- a/Tests/PrivoSDKTests/PrivoSDKTests.swift
+++ b/Tests/PrivoSDKTests/PrivoSDKTests.swift
@@ -35,6 +35,12 @@ final class PrivoSDKTests: XCTestCase {
         // will send one analytic request for bad response:
         let allAnalyticRequests = URLMock.invokedRequests.filter({ $0.url?.isAnalytic ?? false })
         XCTAssertTrue( allAnalyticRequests.count == 1 )
+        if let analyticEventErrorData = allAnalyticRequests.first?.analyticEventErrorData {
+            XCTAssertEqual(analyticEventErrorData.errorCode, 404)
+        } else {
+            XCTFail("Request contains incorrect data.")
+        }
+
     }
 }
 

--- a/Tests/PrivoSDKTests/PrivoSDKTests.swift
+++ b/Tests/PrivoSDKTests/PrivoSDKTests.swift
@@ -9,4 +9,59 @@
             Privo.initialize(settings: PrivoSettings(serviceIdentifier: "privolock", envType: .Dev))
             XCTAssertEqual(PrivoInternal.configuration.type, .Dev)
         }
+
+class URLMock: URLProtocol {
+    typealias URLResult = (error: Error?, data: Data?, response: HTTPURLResponse?)
+   
+    // MARK: class methods
+    
+    // TODO: concurrencty
+    static var urls: [URL: URLResult] = [:]
+    static var invokedRequests: [URLRequest] = []
+    
+    override class func canInit(with request: URLRequest) -> Bool {
+        invokedRequests.append(request)
+                
+        if let requestURL: URL = request.url {
+            return Self.urls[requestURL] != nil
+        } else {
+            return false
+        }
     }
+    
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        // Required to be implemented here. Just return what is passed
+        return request
+    }
+    
+    // MARK: instance methods
+    
+    override func startLoading() {
+        guard let requestURL = request.url,
+              let (error, data, response) = Self.urls[requestURL]
+        else {
+            // unreachable branch
+            let unreachableBranchError = NSError(domain: NSURLErrorDomain, code:NSURLErrorUnknown, userInfo: nil)
+            client?.urlProtocol(self, didFailWithError: unreachableBranchError)
+            return
+        }
+
+        if let response {
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        }
+        
+        if let data {
+            client?.urlProtocol(self, didLoad: data)
+        }
+        
+        if let error {
+            client?.urlProtocol(self, didFailWithError: error)
+        } else {
+            client?.urlProtocolDidFinishLoading(self)
+        }
+    }
+    
+    override func stopLoading() {
+        // Required to be implemented. Do nothing here.
+    }
+}

--- a/Tests/PrivoSDKTests/PrivoSDKTests.swift
+++ b/Tests/PrivoSDKTests/PrivoSDKTests.swift
@@ -10,10 +10,10 @@ final class PrivoSDKTests: XCTestCase {
         Privo.initialize(settings: PrivoSettings(serviceIdentifier: "privolock", envType: .Dev))
 
         // mock requests
-        let statusURL = PrivoInternal.configuration.ageGateBaseUrl.status
-        let analyticURL = PrivoInternal.configuration.commonUrl.analytic
-        let fingerprintURL = PrivoInternal.configuration.authBaseUrl.fingerprint
-        let settingsURL = PrivoInternal.configuration.ageGateBaseUrl.settings
+        let statusURL = PrivoInternal.configuration.ageGateBaseUrl.appending(.status)
+        let analyticURL = PrivoInternal.configuration.commonUrl.appending(.analytic)
+        let fingerprintURL = PrivoInternal.configuration.authBaseUrl.appending(.api).appending(.v1_0).appending(.fingerprint)
+        let settingsURL = PrivoInternal.configuration.ageGateBaseUrl.appending(.settings)
         URLMock.urls = [
             statusURL: (error: nil,
                          data: "The requested resource could not be found.".data(using: .utf8),
@@ -44,7 +44,7 @@ final class PrivoSDKTests: XCTestCase {
         
         // THEN
         // will send one analytic request for bad response:
-        let allAnalyticRequests = URLMock.invokedRequests.filter({ $0.url?.isAnalytic ?? false })
+        let allAnalyticRequests = URLMock.invokedRequests.filter({ $0.url?.hasSuffix(.analytic) ?? false })
         XCTAssertTrue( allAnalyticRequests.count == 1 )
         if let analyticEventErrorData = allAnalyticRequests.first?.analyticEventErrorData {
             XCTAssertEqual(analyticEventErrorData.errorCode, 404)

--- a/Tests/PrivoSDKTests/Requests.swift
+++ b/Tests/PrivoSDKTests/Requests.swift
@@ -1,0 +1,75 @@
+//
+//  File.swift
+//  
+//
+//  Created by Andrey Yo on 21.11.2023.
+//
+
+
+import Foundation
+@testable import PrivoSDK
+
+
+fileprivate extension URLRequest {
+    var data: Data? {
+        let request = self
+        if let stream = request.httpBodyStream {
+            let bufferLength = 1024
+            var buffer = [UInt8](repeating: 0, count: bufferLength)
+
+            if stream.streamStatus != .notOpen {
+                stream.close()
+            }
+            stream.open()
+            
+            var result: Data = Data() // empty data
+            while stream.hasBytesAvailable {
+                let bytesRead = stream.read(&buffer, maxLength: buffer.count)
+                if bytesRead > 0 {
+                    result.append(contentsOf: buffer.prefix(bytesRead))
+                } else if bytesRead < 0 {
+                    // inputStream.streamError was happened
+                    break
+                } else {
+                    // nothing data to read (perhaps, at the end of the stream)
+                    break
+                }
+            }
+            stream.close()
+            return result
+        } else {
+            return request.httpBody
+        }
+    }
+}
+
+
+extension URLRequest {
+    var analyticEvent: AnalyticEvent? {
+        guard let data = self.data else {
+            return nil
+        }
+        
+        do {
+            let decoder = JSONDecoder()
+            let analyticEvent = try decoder.decode(AnalyticEvent.self, from: data)
+            return analyticEvent
+        } catch {
+            return nil
+        }
+    }
+    
+    var analyticEventErrorData: AnalyticEventErrorData? {
+        guard let data = self.analyticEvent?.data?.data(using: .utf8) else {
+            return nil
+        }
+        
+        do {
+            let decoder = JSONDecoder()
+            let analyticEvent = try decoder.decode(AnalyticEventErrorData.self, from: data)
+            return analyticEvent
+        } catch {
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
If the server returns not expected model (for example, 500 or 404 error), the deserialization error happens, and sdk logs this parser error. The current commit changes behaviour, and now the HTTP status code error is handled in a separate way and not mixed.