### PR TITLE
PRIV-7984 Fixing bug with infinity spinner during opening the webview

### DIFF
--- a/Sources/PrivoSDK/components/ModalWebView.swift
+++ b/Sources/PrivoSDK/components/ModalWebView.swift
@@ -10,8 +10,8 @@ import SwiftUI
 struct ModalWebView: View {
     @Binding
     var isPresented: Bool
-    @ObservedObject
-    var model = WebViewModel(permissionService: PrivoCameraPermissionService.shared)
+    
+    private let permissionService = PrivoCameraPermissionService.shared
     
     @State
     private var isLoading: Bool = true
@@ -37,7 +37,7 @@ struct ModalWebView: View {
                       })
                   }
               }
-              Webview(isLoading: $isLoading, viewModel: model, config: config)
+              Webview(isLoading: $isLoading, permissionService: permissionService, config: config)
             }
         
         }

--- a/Sources/PrivoSDK/components/ModalWebView.swift
+++ b/Sources/PrivoSDK/components/ModalWebView.swift
@@ -12,11 +12,15 @@ struct ModalWebView: View {
     var isPresented: Bool
     @ObservedObject
     var model = WebViewModel(permissionService: PrivoCameraPermissionService.shared)
+    
+    @State
+    private var isLoading: Bool = true
+    
     let config: WebviewConfig
   
     var body: some View {
       return
-        LoadingView(isShowing: $model.isLoading) {
+        LoadingView(isShowing: $isLoading) {
             VStack() {
               if (self.config.showCloseIcon) {
                   HStack() {
@@ -33,7 +37,7 @@ struct ModalWebView: View {
                       })
                   }
               }
-              Webview(viewModel: model, config: config)
+              Webview(isLoading: $isLoading, viewModel: model, config: config)
             }
         
         }

--- a/Sources/PrivoSDK/components/Webview.swift
+++ b/Sources/PrivoSDK/components/Webview.swift
@@ -126,9 +126,8 @@ struct Webview: UIViewRepresentable {
         var onLoad: (() -> Void)?
         var onFinish: ((String) -> Void)?
         
-        let fileManager = FileManager()
-        var lastFileDestinationURL: URL?
-        
+        // let fileManager = FileManager()
+        // var lastFileDestinationURL: URL?
         
         init(_ isLoading: Binding<Bool>, _ permissionService: PrivoCameraPermissionServiceType) {
             self._isLoading = isLoading

--- a/Sources/PrivoSDK/components/Webview.swift
+++ b/Sources/PrivoSDK/components/Webview.swift
@@ -12,8 +12,6 @@ struct WebviewConfig {
     var onClose: (() -> Void)?
 }
 class WebViewModel: ObservableObject {
-    @Published
-    var isLoading: Bool = true
     
     let permissionService: PrivoCameraPermissionServiceType
     
@@ -25,6 +23,7 @@ class WebViewModel: ObservableObject {
 struct Webview: UIViewRepresentable {
     
     //MARK: - Internal properties
+    @Binding var isLoading: Bool
     
     @ObservedObject
     var viewModel: WebViewModel
@@ -44,7 +43,7 @@ struct Webview: UIViewRepresentable {
      */
     
     func makeCoordinator() -> WebViewCoordinator {
-        let coordinator = WebViewCoordinator(viewModel)
+        let coordinator = WebViewCoordinator($isLoading, viewModel)
         coordinator.finishCriteria = config.finishCriteria
         coordinator.onFinish = config.onFinish
         coordinator.printCriteria = config.printCriteria
@@ -126,7 +125,10 @@ struct Webview: UIViewRepresentable {
         let fileManager = FileManager()
         var lastFileDestinationURL: URL?
         
-        init(_ viewModel: WebViewModel) {
+        @Binding var isLoading: Bool
+        
+        init(_ isLoading: Binding<Bool>, _ viewModel: WebViewModel) {
+            self._isLoading = isLoading
             self.viewModel = viewModel
         }
         
@@ -150,17 +152,17 @@ struct Webview: UIViewRepresentable {
         }
         
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            viewModel.isLoading = false
+            isLoading = false
         }
 
         /*
         func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-            viewModel.isLoading = true
+            isLoading = true
         }
         */
 
         func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-            viewModel.isLoading = false
+            isLoading = false
         }
         
         func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {

--- a/Sources/PrivoSDK/components/Webview.swift
+++ b/Sources/PrivoSDK/components/Webview.swift
@@ -23,10 +23,11 @@ class WebViewModel: ObservableObject {
 struct Webview: UIViewRepresentable {
     
     //MARK: - Internal properties
-    @Binding var isLoading: Bool
+    @Binding
+    var isLoading: Bool
     
-    @ObservedObject
-    var viewModel: WebViewModel
+    let permissionService: PrivoCameraPermissionServiceType
+    
     let config: WebviewConfig
     
     /*
@@ -43,7 +44,7 @@ struct Webview: UIViewRepresentable {
      */
     
     func makeCoordinator() -> WebViewCoordinator {
-        let coordinator = WebViewCoordinator($isLoading, viewModel)
+        let coordinator = WebViewCoordinator($isLoading, permissionService)
         coordinator.finishCriteria = config.finishCriteria
         coordinator.onFinish = config.onFinish
         coordinator.printCriteria = config.printCriteria
@@ -114,8 +115,11 @@ struct Webview: UIViewRepresentable {
     }
     
     class WebViewCoordinator: NSObject, WKNavigationDelegate, WKUIDelegate {
-        private var viewModel: WebViewModel
+        private var permissionService: PrivoCameraPermissionServiceType
         private let printLoadingHelper = PrintLoadingHelper();
+        
+        @Binding
+        private var isLoading: Bool
         
         var printCriteria: String?
         var finishCriteria: String?
@@ -125,11 +129,10 @@ struct Webview: UIViewRepresentable {
         let fileManager = FileManager()
         var lastFileDestinationURL: URL?
         
-        @Binding var isLoading: Bool
         
-        init(_ isLoading: Binding<Bool>, _ viewModel: WebViewModel) {
+        init(_ isLoading: Binding<Bool>, _ permissionService: PrivoCameraPermissionServiceType) {
             self._isLoading = isLoading
-            self.viewModel = viewModel
+            self.permissionService = permissionService
         }
         
         func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
@@ -207,7 +210,7 @@ struct Webview: UIViewRepresentable {
                      initiatedByFrame frame: WKFrameInfo,
                      type: WKMediaCaptureType,
                      decisionHandler: @escaping (WKPermissionDecision) -> Void) {
-            viewModel.permissionService.checkPermission(for: type, completion: decisionHandler)
+            permissionService.checkPermission(for: type, completion: decisionHandler)
         }
         
         class PrintLoadingHelper: NSObject, WKNavigationDelegate {


### PR DESCRIPTION
There is a floating bug while the webview is open. Loading spinner does not hide. The reason is incorrect using init with ObservedObject. Unfortunately, StateObject is available since only iOS14. So this PR offers a solution based on State property wrapper usage.